### PR TITLE
[PIN-3388] New Attributes Structure

### DIFF
--- a/src/main/scala/it/pagopa/interop/apigateway/api/impl/GatewayApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/apigateway/api/impl/GatewayApiServiceImpl.scala
@@ -502,9 +502,9 @@ final case class GatewayApiServiceImpl(
       tenant           <- tenantManagementService.getTenantById(eService.producerId)
       latestDescriptor <- eService.latestAvailableDescriptor
       state            <- latestDescriptor.state.toModel.toFuture
-      allAttributesIds = eService.attributes.allIds
+      allAttributesIds = latestDescriptor.attributes.allIds
       attributes <- attributeRegistryManagementService.getBulkAttributes(allAttributesIds)
-      attributes <- eService.attributes.toModel(attributes.attributes).toFuture
+      attributes <- latestDescriptor.attributes.toModel(attributes.attributes).toFuture
       category   <- extractCategoryIpa(tenant)
     } yield EService(
       id = eService.id,

--- a/src/test/scala/it/pagopa/interop/apigateway/ClientRetrieveSpec.scala
+++ b/src/test/scala/it/pagopa/interop/apigateway/ClientRetrieveSpec.scala
@@ -109,7 +109,6 @@ class ClientRetrieveSpec extends AnyWordSpecLike with SpecHelper with ScalatestR
         name = "EService",
         description = "Description",
         technology = CatalogManagement.EServiceTechnology.REST,
-        attributes = CatalogManagement.Attributes(Seq.empty, Seq.empty, Seq.empty),
         descriptors = Seq.empty
       )
 
@@ -180,7 +179,6 @@ class ClientRetrieveSpec extends AnyWordSpecLike with SpecHelper with ScalatestR
         name = "EService",
         description = "Description",
         technology = CatalogManagement.EServiceTechnology.REST,
-        attributes = CatalogManagement.Attributes(Seq.empty, Seq.empty, Seq.empty),
         descriptors = Seq.empty
       )
 


### PR DESCRIPTION
The only logical change that this PR brings is that for these 2 endpoints

```
/eservices/{eserviceId}
/organizations/origin/{origin}/externalId/{externalId}/eservices
```

the returned Eservice model

```
EService:
  - id
  - producer
  - name
  - version
  - description
  - technology
  - attributes
  - state
  - serverUrls
```

won't change shape but the `attributes` field, that atm is populated reading the attributes from the eService model in the Catalog Management, will be populated using the attributes of the last descriptor that the eservices contains.

Given that `version` and `serverUrls` were already referring to the last descriptor, I thought that this could have been the most straightforward way to implement the change, wdyt? 